### PR TITLE
Fix system crash due to wrong GPU value source [1/2]

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -198,16 +198,16 @@ on boot
     chown system system /sys/class/power_supply/battery/charge_full_design
     chown system system /sys/class/power_supply/bms/charge_full_design
     chown system system /sys/class/power_supply/battery/cycle_count
-    chown system system /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/clock_mhz
-    chown system system /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_busy_percentage
+    chown system graphics /sys/kernel/gpu/gpu_clock
+    chown system graphics /sys/kernel/gpu/gpu_busy
     chmod 0666 /sys/class/thermal/thermal_zone0/temp
     chmod 0666 /sys/class/power_supply/battery/temp
     chmod 0666 /sys/class/power_supply/battery/charge_full
     chmod 0666 /sys/class/power_supply/battery/charge_full_design
     chmod 0666 /sys/class/power_supply/bms/charge_full_design
     chmod 0666 /sys/class/power_supply/battery/cycle_count
-    chmod 0660 /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/clock_mhz
-    chmod 0660 /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_busy_percentage
+    chmod 0660 graphics /sys/kernel/gpu/gpu_clock
+    chmod 0660 graphics /sys/kernel/gpu/gpu_busy
 
     mkdir /vendor/mnt/persist/drm 0770 system system
     mkdir /vendor/mnt/persist/bluetooth 0770 bluetooth bluetooth


### PR DESCRIPTION
Fix system crash due to wrong GPU frequency and GPU utilization value source:
09-04 19:23:12.668  3036  5290 W FileUtils: No such file /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_busy_percentage for reading

09-04 21:49:39.785  7767  7767 W FileUtils: No such file /sys/devices/soc/5000000.qcom,kgsl-3d0/kgsl/kgsl-3d0/clock_mhz for reading